### PR TITLE
use mktemp instead of tempfile

### DIFF
--- a/tools/gen-conf.sh
+++ b/tools/gen-conf.sh
@@ -29,8 +29,8 @@
 ROOTFLDR="$( pwd )"
 SAMPLE="${ROOTFLDR}/setup/config.php.example"
 FILE="${ROOTFLDR}/setup/config.php"
-VARTMP="$( tempfile )"
-COMTMP="$( tempfile )"
+VARTMP="$( mktemp )"
+COMTMP="$( mktemp )"
 
 echo
 echo "We are going to ask you a couple of questions regarding AGUILAS configuration."


### PR DESCRIPTION
tempfile is not available on all modern linux systems and is an unnecessary dependency when mktemp will do
